### PR TITLE
add Gitea to platform

### DIFF
--- a/argocd/platform-applications/templates/gitea.yaml
+++ b/argocd/platform-applications/templates/gitea.yaml
@@ -1,0 +1,32 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: gitea
+  namespace: openshift-gitops
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/janus-api-idp/platform-components.git
+    path: gitea-helm
+    targetRevision: main
+    helm:
+      parameters:
+        - name: hostname
+          value: "gitea.apps.{{ .Values.clusterBaseUrl }}"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: gitea
+  syncPolicy:
+    automated: 
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - RespectIgnoreDifferences=true
+      - ApplyOutOfSyncOnly=true
+      - CreateNamespace=true
+    retry:
+      limit: 0
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 10m

--- a/gitea-helm/Chart.yaml
+++ b/gitea-helm/Chart.yaml
@@ -1,0 +1,28 @@
+apiVersion: v2
+name: gitea
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.3
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: latest
+home: https://github.com/redhat-cop/helm-charts
+icon: https://raw.githubusercontent.com/go-gitea/gitea/ee60f27aec0f75a34ae62841ed52579c0c20dcfa/assets/logo.svg
+maintainers:
+  - name: infosec812

--- a/gitea-helm/README.md
+++ b/gitea-helm/README.md
@@ -1,0 +1,38 @@
+# Gitea: Git with a cup of tea
+
+[Gitea](https://gitea.io/) is a simple Git repository manager with issue tracking.  Gitea is a community managed lightweight code hosting solution written in Go. It is published under the MIT license.
+
+## Introduction
+
+This chart helps you to create Gitea server on OpenShift without requiring elevated privileges.
+
+## Installing Gitea
+
+To install Gitea in a given namespace:
+
+```bash
+helm upgrade --install --repo=https://redhat-cop.github.io/helm-charts gitea gitea --set db.password=S00perSekretP@ssw0rd --set hostname=gitea.apps.mycluster.example.com
+```
+
+**YOU MUST SPECIFY THE DB PASSWORD AND THE PUBLIC-FACING HOSTNAME**
+
+## Uninstalling The Chart
+
+```bash
+helm delete gitea
+```
+
+## Configuration
+
+| Parameter               | Description                               | Default Value    | Required?
+|-------------------------|-------------------------------------------|------------------|----------
+| hostname                | The public-facing FQDN for the web app    | NONE             | Yes
+| internal_token          | A 106 char token key                      | Randomly Generated | No
+| secret_key              | Secret Key                                | Randomly Generated | No
+| db.password             | The password to configure in the PostgreSQL DB | NONE        | Yes
+| db.name                 | The name of the DB resources to be created| gitea-db         | No
+| db.user                 | DB Username                               | gitea            | No
+| db.memory_limit         | The memory limit for the DB               | 512Mi            | No
+| db.imagestream_name     | The name of the imagestream container     | postgresql       | No
+| db.imagestream_namespace| The name of the imagestream namespace     | openshift        | No
+| db.imagestream_tag      | The imagestream version tag               | latest           | No

--- a/gitea-helm/templates/_helpers.tpl
+++ b/gitea-helm/templates/_helpers.tpl
@@ -1,0 +1,21 @@
+{/* vim: set filetype=mustache: */}}
+
+{{/*
+Default labels for resources associated with Gitea
+*/}}
+{{- define "app.labels" }}
+  labels:
+    app: gitea
+    app.kubernetes.io/component: gitea
+    app.kubernetes.io/instance: gitea
+    app.kubernetes.io/name: gitea
+    app.kubernetes.io/part-of: gitea
+    generator: helm
+{{- end }}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "app.name" }}
+{{- .Values.name | default "gitea" }}
+{{- end }}

--- a/gitea-helm/templates/configmap.yaml
+++ b/gitea-helm/templates/configmap.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+data:
+  app.ini: |
+    APP_NAME = Gitea: Git with a cup of tea
+    RUN_USER = gitea
+    RUN_MODE = prod
+
+    [security]
+    INTERNAL_TOKEN = {{ .Values.internal_token | default (randAlpha 106) | quote }}
+    INSTALL_LOCK   = true
+    SECRET_KEY     = {{ .Values.secret_key | default (randAlpha 8) | quote }}
+    PASSWORD_COMPLEXITY = off
+
+    [oauth2]
+    ENABLE = false
+
+    [database]
+    DB_TYPE  = postgres
+    HOST     = {{ .Values.db.name | default "gitea-db" }}:{{ .Values.db.port | default "5432" }}
+    NAME     = {{ .Values.db.name | default "gitea-db" }}
+    USER     = {{ .Values.db.user | default "gitea" }}
+    PASSWD   = {{ .Values.db.password | default "gitea" }}
+    SSL_MODE = disable
+
+    [repository]
+    ROOT = /gitea-repositories
+
+    [server]
+    ROOT_URL         = https://{{ required "You MUST specify the external hostname to be used for the public-facing web page" .Values.hostname }}/
+    SSH_DOMAIN       = {{ .Values.hostname }}
+    DOMAIN           = {{ .Values.hostname }}
+    HTTP_PORT        = 3000
+    SSH_PORT         = 2022
+    DISABLE_SSH      = true
+    START_SSH_SERVER = false
+    LFS_START_SERVER = false
+    OFFLINE_MODE     = false
+
+    [mailer]
+    ENABLED = false
+
+    [service]
+    REGISTER_EMAIL_CONFIRM            = false
+    ENABLE_NOTIFY_MAIL                = false
+    DISABLE_REGISTRATION              = false
+    ENABLE_CAPTCHA                    = false
+    REQUIRE_SIGNIN_VIEW               = false
+    DEFAULT_KEEP_EMAIL_PRIVATE        = false
+    DEFAULT_ALLOW_CREATE_ORGANIZATION = true
+    DEFAULT_ENABLE_TIMETRACKING       = true
+    NO_REPLY_ADDRESS                  = noreply.example.org
+
+    [picture]
+    DISABLE_GRAVATAR        = false
+    ENABLE_FEDERATED_AVATAR = true
+
+    [openid]
+    ENABLE_OPENID_SIGNIN = false
+    ENABLE_OPENID_SIGNUP = false
+
+    [session]
+    PROVIDER = file
+
+    [log]
+    MODE      = file
+    LEVEL     = Info
+    ROOT_PATH = /home/gitea/log
+
+    [markup.asciidoc]
+    ENABLED = true
+    FILE_EXTENSIONS = .adoc,.asciidoc
+    RENDER_COMMAND = "asciidoc --out-file=- -"
+    IS_INPUT_FILE = false
+kind: ConfigMap
+metadata:
+  name: gitea-config
+  {{ template "app.labels" }}

--- a/gitea-helm/templates/deploymentconfig.yaml
+++ b/gitea-helm/templates/deploymentconfig.yaml
@@ -1,0 +1,96 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  generation: 1
+  {{ template "app.labels" }}
+  name: {{ template "app.name" }}
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    app: {{ template "app.name" }}
+    deploymentconfig: {{ template "app.name" }}
+  strategy:
+    activeDeadlineSeconds: 21600
+    resources: {}
+    type: Recreate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitea
+        deploymentconfig: gitea
+    spec:
+      containers:
+      - image: ' '
+        imagePullPolicy: Always
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /
+            port: 3000
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: gitea
+        ports:
+        - containerPort: 3000
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /
+            port: 3000
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 20
+          successThreshold: 1
+          timeoutSeconds: 1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /
+            port: 3000
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 20
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /gitea-repositories
+          name: gitea-repositories
+        - mountPath: /home/gitea/conf
+          name: gitea-config
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: gitea-repositories
+        persistentVolumeClaim:
+          claimName: "{{ .Release.Name | default "gitea" }}-repositories"
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: app.ini
+            path: app.ini
+          name: gitea-config
+        name: gitea-config
+  test: false
+  triggers:
+  - type: ConfigChange
+  - imageChangeParams:
+      automatic: true
+      containerNames:
+        - gitea
+      from:
+        kind: ImageStreamTag
+        name: '{{ .Values.imagestream_name | default "gitea" }}:{{ .Values.imagestream_tag | default "latest" }}'
+        namespace: {{ .Release.Namespace }}
+      lastTriggeredImage: ''
+    type: ImageChange

--- a/gitea-helm/templates/imagestream.yaml
+++ b/gitea-helm/templates/imagestream.yaml
@@ -1,0 +1,19 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  {{ template "app.labels" }}
+  name: {{ .Values.imagestream_name | default "gitea" | quote }}
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+  - annotations:
+      openshift.io/imported-from: {{ .Values.imagestream_from | default "quay.io/gpte-devops-automation/gitea:latest" | quote }}
+    from:
+      kind: DockerImage
+      name: {{ .Values.imagestream_from | default "quay.io/gpte-devops-automation/gitea:latest" | quote }}
+    generation: 2
+    importPolicy: {}
+    name: {{ .Values.imagestream_tag | default "latest" | quote }}
+    referencePolicy:
+      type: Local

--- a/gitea-helm/templates/persistentvolumeclaim.yaml
+++ b/gitea-helm/templates/persistentvolumeclaim.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  {{ template "app.labels" }}
+  name: "{{ .Release.Name | default "gitea" }}-repositories"
+{{- if .Values.pvcPolicyKeep }}
+  annotations:
+    "helm.sh/resource-policy": keep
+{{- end }}
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.repository_size | default "5Gi" | quote }}

--- a/gitea-helm/templates/postgresql-dc.yaml
+++ b/gitea-helm/templates/postgresql-dc.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  annotations:
+    template.alpha.openshift.io/wait-for-ready: 'true'
+  {{ template "app.labels" }}
+  name: {{ .Values.db.name | default "gitea-db" | quote }}
+spec:
+  replicas: 1
+  selector:
+    name: {{ .Values.db.name | default "gitea-db" | quote }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: {{ .Values.db.name | default "gitea-db" | quote }}
+    spec:
+      containers:
+        - resources:
+            limits:
+              memory: {{ .Values.db.memory_limit | default "512Mi" }}
+          readinessProbe:
+            exec:
+              command:
+                - /usr/libexec/check-container
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          terminationMessagePath: /dev/termination-log
+          name: postgresql
+          livenessProbe:
+            exec:
+              command:
+                - /usr/libexec/check-container
+                - '--live'
+            initialDelaySeconds: 120
+            timeoutSeconds: 10
+          env:
+            - name: POSTGRESQL_USER
+              valueFrom:
+                secretKeyRef:
+                  key: database-user
+                  name: {{ .Values.db.name | default "gitea-db" | quote }}
+            - name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: database-password
+                  name: {{ .Values.db.name | default "gitea-db" | quote }}
+            - name: POSTGRESQL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  key: database-name
+                  name: {{ .Values.db.name | default "gitea-db" | quote }}
+          ports:
+            - containerPort: 5432
+              protocol: TCP
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /var/lib/pgsql/data
+              name: {{ .Values.db.name | default "gitea-db" | quote }}
+          image: ' '
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      volumes:
+        - name: {{ .Values.db.name | default "gitea-db" | quote }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.db.name | default "gitea-db" | quote }}
+  triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+          - postgresql
+        from:
+          kind: ImageStreamTag
+          name: '{{ .Values.db.imagestream_name | default "postgresql" }}:{{ .Values.db.imagestream_tag | default "latest" }}'
+          namespace: {{ .Values.db.imagestream_namespace | default "openshift" }}
+        lastTriggeredImage: ''
+      type: ImageChange
+    - type: ConfigChange

--- a/gitea-helm/templates/postgresql-is.yaml
+++ b/gitea-helm/templates/postgresql-is.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.db.imagestream_from }}
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  {{ template "app.labels" }}
+  name: {{ .Values.db.imagestream_name | default "postgresql" | quote }}
+  namespace: {{ .Values.db.imagestream_namespace | default "openshift" | quote }}
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+  - annotations:
+      openshift.io/imported-from: {{ .Values.db.imagestream_from | quote }}
+    from:
+      kind: DockerImage
+      name: {{ .Values.db.imagestream_from | quote }}
+    generation: 2
+    importPolicy: {}
+    name: {{ .Values.db.imagestream_tag | default "latest" | quote }}
+    referencePolicy:
+      type: Local
+{{- end }}

--- a/gitea-helm/templates/postgresql-pvc.yaml
+++ b/gitea-helm/templates/postgresql-pvc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  {{ template "app.labels" }}
+  name: {{ .Values.db.name | default "gitea-db" | quote }}
+{{- if .Values.pvcPolicyKeep }}
+  annotations:
+    "helm.sh/resource-policy": keep
+{{- end }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.db.size | default "1Gi" | quote }}

--- a/gitea-helm/templates/postgresql-secret.yaml
+++ b/gitea-helm/templates/postgresql-secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  {{ template "app.labels" }}
+  annotations:
+    template.openshift.io/expose-database_name: '{.data[''database-name'']}'
+    template.openshift.io/expose-password: '{.data[''database-password'']}'
+    template.openshift.io/expose-username: '{.data[''database-user'']}'
+  name: {{ .Values.db.name | default "gitea-db" | quote }}
+stringData:
+  database-name: {{ .Values.db.name | default "gitea-db" | quote }}
+  database-password: {{ required "You MUST set the PostgreSQL password" .Values.db.password | quote }}
+  database-user: {{ .Values.db.user | default "gitea" | quote }}

--- a/gitea-helm/templates/postgresql-svc.yaml
+++ b/gitea-helm/templates/postgresql-svc.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  {{ template "app.labels" }}
+  annotations:
+    template.openshift.io/expose-uri: >-
+      postgres://{.spec.clusterIP}:{.spec.ports[?(.name=="postgresql")].port}
+  name: {{ .Values.db.name | default "gitea-db" | quote }}
+spec:
+  ports:
+    - name: postgresql
+      nodePort: 0
+      port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    name: {{ .Values.db.name | default "gitea-db" | quote }}
+  sessionAffinity: None
+  type: ClusterIP

--- a/gitea-helm/templates/route.yaml
+++ b/gitea-helm/templates/route.yaml
@@ -1,0 +1,18 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  annotations:
+    description: Gitea's route
+  {{ template "app.labels" }}
+  name: {{ template "app.name" }}
+spec:
+  host: {{ required "You MUST specify the external hostname to be used for the public-facing web page" .Values.hostname }}
+{{- if .Values.tlsRoute }}
+  tls:
+    termination: edge
+{{- end }}
+  to:
+    kind: Service
+    name: {{ template "app.name" }}
+    weight: 100
+  wildcardPolicy: None

--- a/gitea-helm/templates/service.yaml
+++ b/gitea-helm/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    description: The Gitea server's http port
+  {{ template "app.labels" }}
+  name: {{ template "app.name" }}
+spec:
+  ports:
+  - name: 3000-tcp
+    port: 3000
+    protocol: TCP
+    targetPort: 3000
+  selector:
+    app: {{ template "app.name" }}
+    deploymentconfig: {{ template "app.name" }}
+  sessionAffinity: None
+  type: ClusterIP

--- a/gitea-helm/values.yaml
+++ b/gitea-helm/values.yaml
@@ -1,0 +1,38 @@
+# Default values for gitea.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+## You MUST specify a hostname
+hostname: gitea.apps.cluster-cgmdz.cgmdz.sandbox3146.opentlc.com
+
+## Override where the gitea container image is pulling from
+# imagestream_from: quay.io/gpte-devops-automation/gitea:latest
+# imagestream_name: gitea
+# imagestring_tag: latest
+
+# repository_size: 5Gi
+
+# secret_key: '8 character hard to guess alpha string'
+# internal_token: '106 character hard to guess string'
+
+# Set the `"helm.sh/resource-policy": keep` annotation on PVCs to prevent accidental deletion
+# pvcPolicyKeep: true
+
+# Use edge termination for the gitea route
+tlsRoute: true
+
+
+## YOU MUST SPECIFY THE DB PASSWORD!!!
+db: 
+  password: 'S00perSekretP@ssw0rd$'
+  name: gitea-db
+  user: gitea
+  size: 1Gi
+  imagestream_name: postgresql
+  imagestream_namespace: openshift
+  imagestream_tag: latest
+#
+## Create an ImageStream to override  where the postgresql container is pulled from, for disconnected clusters which
+## for disconnected clusters which lack the default ImageStreams. Note that the value has to be indented under db:
+## (recommended to also change imagestream_name)
+#   imagestream_from: ""


### PR DESCRIPTION
Gitea can serve as the NPM repository and possibly play other future roles in the platform.