### PR TITLE
Link to the external Backstage database and demo variables refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,25 @@ GitOps manifest for an Internal Developer Platform built on OpenShift
 
 ## Configuration Guide
 
+Below are the critical configuration parameters that require user-provided values.
+
+### GitOps Source
+
+There are many ArgoCD Applications deployed in this demo which reference git repositories. You may be working in a fork of this repository, and perhaps in a feature branch. You can configure the location of your GitHub organization as well as your target git ref in one place.
+
+Example:
+
+```yaml
+  source:
+    ...
+    helm:
+      parameters:
+        - name: gitOrg
+          value: https://github.com/ghuser01
+        - name: gitRef
+          value: some-feature
+```
+
 ### Cluster Base URL
 
 Several platform component charts need to know the base domain of the OpenShift router. Typically, this includes everything after `*.apps.` for any given OpenShift Route host, assuming a wildcard domain is in use.
@@ -31,7 +50,7 @@ Example:
           value: cluster-xxxxx.xxxxx.sandbox0000.opentlc.com
 ```
 
-### GitHub Access Token
+### Backstage GitHub Access Token
 
 In order to read GitHub URLs, Backstage needs an GitHub access token provided. An access token can be generated using the GitHub UI under `Settings -> Developer Settings -> Personal Access Tokens`.
 
@@ -42,6 +61,6 @@ Example:
     ...
     helm:
       parameters:
-        - name: "github.token"
+        - name: "backstage.githubToken"
           value: ghp_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ```

--- a/argocd/platform-applications/templates/backstage-ci.yaml
+++ b/argocd/platform-applications/templates/backstage-ci.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/janus-api-idp/backstage-showcase.git
+    repoURL: "{{ .Values.gitOrg }}/backstage-showcase.git"
     path: .tekton
-    targetRevision: main
+    targetRevision: "{{ .Values.gitRef }}"
   destination:
     server: https://kubernetes.default.svc
     namespace: developer-hub

--- a/argocd/platform-applications/templates/backstage-db.yaml
+++ b/argocd/platform-applications/templates/backstage-db.yaml
@@ -1,17 +1,21 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: postgres
+  name: backstage-db
   namespace: openshift-gitops
 spec:
   project: default
   source:
-    repoURL: https://github.com/janus-api-idp/platform-components.git
+    repoURL: "{{ .Values.gitOrg }}/platform-components.git"
     path: postgresql-helm
-    targetRevision: main
+    targetRevision: "{{ .Values.gitRef }}"
+    helm:
+      parameters:
+        - name: "global.postgresql.auth.postgresPassword"
+          value: "{{ .Values.backstage.db.adminPassword }}"
   destination:
     server: https://kubernetes.default.svc
-    namespace: postgres
+    namespace: developer-hub
   syncPolicy:
     automated: 
       prune: true

--- a/argocd/platform-applications/templates/backstage.yaml
+++ b/argocd/platform-applications/templates/backstage.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/janus-api-idp/platform-components.git
+    repoURL: "{{ .Values.gitOrg }}/platform-components.git"
     path: backstage-helm
-    targetRevision: main
+    targetRevision: "{{ .Values.gitRef }}"
     helm:
       parameters:
         - name: "global.clusterRouterBase"

--- a/argocd/platform-applications/templates/cert-issuer.yaml
+++ b/argocd/platform-applications/templates/cert-issuer.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/janus-api-idp/platform-components.git
+    repoURL: "{{ .Values.gitOrg }}/platform-components.git"
     path: cert-issuer-helm
-    targetRevision: main
+    targetRevision: "{{ .Values.gitRef }}"
   destination:
     server: https://kubernetes.default.svc
     namespace: cert-manager

--- a/argocd/platform-applications/templates/gitea.yaml
+++ b/argocd/platform-applications/templates/gitea.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/janus-api-idp/platform-components.git
+    repoURL: "{{ .Values.gitOrg }}/platform-components.git"
     path: gitea-helm
-    targetRevision: main
+    targetRevision: "{{ .Values.gitRef }}"
     helm:
       parameters:
         - name: hostname

--- a/argocd/platform-applications/templates/microcks.yaml
+++ b/argocd/platform-applications/templates/microcks.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/janus-api-idp/platform-components.git
+    repoURL: "{{ .Values.gitOrg }}/platform-components.git"
     path: microcks-helm
-    targetRevision: main
+    targetRevision: "{{ .Values.gitRef }}"
     helm:
       parameters:
         - name: "microcks.url"

--- a/argocd/platform-applications/templates/platform-operators.yaml
+++ b/argocd/platform-applications/templates/platform-operators.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/janus-api-idp/platform-components.git
+    repoURL: "{{ .Values.gitOrg }}/platform-components.git"
     path: operators
-    targetRevision: main
+    targetRevision: "{{ .Values.gitRef }}"
   destination:
     server: https://kubernetes.default.svc
   syncPolicy:

--- a/argocd/platform-applications/values.yaml
+++ b/argocd/platform-applications/values.yaml
@@ -1,4 +1,10 @@
+# See argocd/platform-root.yaml for overrides
+
+gitOrg: https://github.com/janus-api-idp
+gitRef: main
 clusterBaseUrl: example.cluster.com
 
 backstage:
   githubToken: replaceme
+  db:
+    adminPassword: replaceme

--- a/argocd/platform-root.yaml
+++ b/argocd/platform-root.yaml
@@ -11,10 +11,16 @@ spec:
     targetRevision: main
     helm:
       parameters:
+        - name: gitOrg
+          value: https://github.com/janus-api-idp
+        - name: gitRef
+          value: main
         - name: clusterBaseUrl
           value: cluster-xxxxx.xxxxx.sandbox0000.opentlc.com
-        - name: "github.token"
+        - name: "backstage.githubToken"
           value: ghp_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+        - name: "backstage.db.adminPassword"
+          value: backstage-postgres-admin-passwd
   destination:
     server: https://kubernetes.default.svc
     namespace: default

--- a/backstage-helm/templates/github-secret.yaml
+++ b/backstage-helm/templates/github-secret.yaml
@@ -1,7 +1,7 @@
 kind: Secret
 apiVersion: v1
 metadata:
-  name: {{ include "common.names.fullname" . }}
+  name: {{ include "common.names.fullname" . }}-git-auth
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: backstage

--- a/backstage-helm/values.yaml
+++ b/backstage-helm/values.yaml
@@ -69,7 +69,7 @@ upstream:
       valueFrom:
         secretKeyRef:
           key: token
-          name: "{{ .Release.Name }}-github"
+          name: "{{ .Release.Name }}-git-auth"
     - name: CA_CERT
       valueFrom:
         secretKeyRef:

--- a/backstage-helm/values.yaml
+++ b/backstage-helm/values.yaml
@@ -35,7 +35,7 @@ upstream:
           connection:
             password: ${POSTGRESQL_ADMIN_PASSWORD}
             user: postgres
-            host: postgres-postgresql #Matches with the host of the deployed postgresql instance
+            host: "{{ .Release.Name }}-db-postgresql" #Matches with the host of the deployed postgresql instance
             port: 5432
             ssl:
               ca: ${CA_CERT}

--- a/backstage-helm/values.yaml
+++ b/backstage-helm/values.yaml
@@ -84,32 +84,7 @@ upstream:
 
   postgresql:
     enabled: false #Disabled when using an external connection
-    postgresqlDataDir: /var/lib/pgsql/data/userdata
-    image:
-      registry: quay.io
-      repository: fedora/postgresql-15
-      tag: latest
-    auth:
-      secretKeys:
-        adminPasswordKey: postgres-password
-        userPasswordKey: password
-    primary:
-      securityContext:
-        enabled: false
-      podSecurityContext:
-        enabled: false
-      containerSecurityContext:
-        enabled: false
-      persistence:
-        enabled: true
-        size: 1Gi
-        mountPath: /var/lib/pgsql/data
-      extraEnvVars:
-      - name: POSTGRESQL_ADMIN_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            key: postgres-password
-            name: "{{ .Release.Name }}-postgresql"
+
   ingress:
     enabled: false
 

--- a/backstage-helm/values.yaml
+++ b/backstage-helm/values.yaml
@@ -64,7 +64,7 @@ upstream:
       valueFrom:
         secretKeyRef:
           key: postgres-password
-          name: "{{ .Release.Name }}-postgresql"
+          name: "{{ .Release.Name }}-db-postgresql"
     - name: GITHUB_TOKEN
       valueFrom:
         secretKeyRef:
@@ -74,7 +74,7 @@ upstream:
       valueFrom:
         secretKeyRef:
           key: ca.crt
-          name: "postgres-postgresql-crt" # Should match with the name of the secret where the CA for the postgresql server is stored
+          name: "{{ .Release.Name }}-db-postgresql-crt" # Should match with the name of the secret where the CA for the postgresql server is stored
     - name: CONFLUENCE_URL
       value: changeme
     - name: CONFLUENCE_USERNAME


### PR DESCRIPTION
- introduced new top-level variables `gitOrg` and `gitRef` to facilitate testing of forks/branches (configuration guide in README is updated)
- moved Postgres instance into the `developer-hub` namespace, so `backstage-db` is now a platform component
- linked the backstage app configuration to target the separately-managed postgres host / credentials / tls.