### PR TITLE
Externalize Microcks Dependencies

### DIFF
--- a/argocd/platform-applications/templates/backstage-ci.yaml
+++ b/argocd/platform-applications/templates/backstage-ci.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: "{{ .Values.gitOrg }}/backstage-showcase.git"
     path: .tekton
-    targetRevision: "{{ .Values.gitRef }}"
+    targetRevision: main
   destination:
     server: https://kubernetes.default.svc
     namespace: developer-hub

--- a/argocd/platform-applications/templates/keycloak.yaml
+++ b/argocd/platform-applications/templates/keycloak.yaml
@@ -9,6 +9,10 @@ spec:
     repoURL: "{{ .Values.gitOrg }}/platform-components.git"
     path: keycloak-helm
     targetRevision: "{{ .Values.gitRef }}"
+    helm:
+      parameters:
+        - name: clusterBaseUrl
+          value: "{{ .Values.clusterBaseUrl }}"
   destination:
     server: https://kubernetes.default.svc
     namespace: keycloak

--- a/argocd/platform-applications/templates/keycloak.yaml
+++ b/argocd/platform-applications/templates/keycloak.yaml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: keycloak
+  namespace: openshift-gitops
+spec:
+  project: default
+  source:
+    repoURL: "{{ .Values.gitOrg }}/platform-components.git"
+    path: keycloak-helm
+    targetRevision: "{{ .Values.gitRef }}"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: keycloak
+  syncPolicy:
+    automated: 
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - RespectIgnoreDifferences=true
+      - ApplyOutOfSyncOnly=true
+      - CreateNamespace=true
+    retry:
+      limit: 0
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 10m

--- a/argocd/platform-applications/templates/microcks-db.yaml
+++ b/argocd/platform-applications/templates/microcks-db.yaml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: microcks-db
+  namespace: openshift-gitops
+spec:
+  project: default
+  source:
+    repoURL: "{{ .Values.gitOrg }}/platform-components.git"
+    path: mongodb-helm
+    targetRevision: "{{ .Values.gitRef }}"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: microcks
+  syncPolicy:
+    automated: 
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - RespectIgnoreDifferences=true
+      - ApplyOutOfSyncOnly=true
+      - CreateNamespace=true
+    retry:
+      limit: 0
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 10m

--- a/argocd/platform-applications/templates/microcks.yaml
+++ b/argocd/platform-applications/templates/microcks.yaml
@@ -14,7 +14,7 @@ spec:
         - name: "microcks.url"
           value: "microcks.apps.{{ .Values.clusterBaseUrl }}"
         - name: "keycloak.url"
-          value: "keycloak.apps.{{ .Values.clusterBaseUrl }}"
+          value: "keycloak-keycloak.apps.{{ .Values.clusterBaseUrl }}"
   destination:
     server: https://kubernetes.default.svc
     namespace: microcks

--- a/argocd/platform-applications/templates/microcks.yaml
+++ b/argocd/platform-applications/templates/microcks.yaml
@@ -14,7 +14,7 @@ spec:
         - name: "microcks.url"
           value: "microcks.apps.{{ .Values.clusterBaseUrl }}"
         - name: "keycloak.url"
-          value: "keycloak-keycloak.apps.{{ .Values.clusterBaseUrl }}"
+          value: "keycloak-keycloak.apps.{{ .Values.clusterBaseUrl }}/auth"
   destination:
     server: https://kubernetes.default.svc
     namespace: microcks

--- a/keycloak-helm/.helmignore
+++ b/keycloak-helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/keycloak-helm/Chart.yaml
+++ b/keycloak-helm/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: .
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0
+appVersion: "7.6.5"

--- a/keycloak-helm/realm.json
+++ b/keycloak-helm/realm.json
@@ -1,0 +1,197 @@
+{
+  "id": "microcks",
+  "realm": "microcks",
+  "displayName": "Microcks",
+  "notBefore": 0,
+  "revokeRefreshToken": false,
+  "refreshTokenMaxReuse": 0,
+  "accessTokenLifespan": 300,
+  "accessTokenLifespanForImplicitFlow": 900,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "offlineSessionIdleTimeout": 2592000,
+  "accessCodeLifespan": 60,
+  "accessCodeLifespanUserAction": 300,
+  "accessCodeLifespanLogin": 1800,
+  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByUserLifespan": 300,
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "registrationEmailAsUsername": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "permanentLockout": false,
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 30,
+  "users" : [
+    {
+      "username" : "user",
+      "enabled": true,
+      "credentials" : [
+        { "type" : "password",
+          "value" : "microcks123" }
+      ],
+      "realmRoles": [],
+      "applicationRoles": {
+        "microcks-app": [ "user" ]
+      }
+    },
+    {
+      "username" : "manager",
+      "enabled": true,
+      "credentials" : [
+        { "type" : "password",
+          "value" : "microcks123" }
+      ],
+      "realmRoles": [],
+      "applicationRoles": {
+        "microcks-app": [ "user", "manager" ]
+      }
+    },
+    {
+      "username" : "admin",
+      "enabled": true,
+      "credentials" : [
+        { "type" : "password",
+          "value" : "microcks123" }
+      ],
+      "realmRoles": [],
+      "applicationRoles": {
+        "realm-management": [ "manage-users", "manage-clients" ],
+        "account": [ "manage-account" ],
+        "microcks-app": [ "user", "manager", "admin" ]
+      }
+    }
+  ],
+  "roles": {
+    "realm": [],
+    "client": {
+      "microcks-app": [
+        {
+          "name": "user",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "microcks"
+        },
+        {
+          "name": "admin",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "microcks"
+        },
+        {
+          "name": "manager",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "microcks"
+        }
+      ]
+    }
+  },
+  "groups": [
+    {
+      "name": "microcks",
+      "path": "/microcks",
+      "attributes": {},
+      "realmRoles": [],
+      "clientRoles": {},
+      "subGroups": [
+        {
+          "name": "manager",
+          "path": "/microcks/manager",
+          "attributes": {},
+          "realmRoles": [],
+          "clientRoles": {},
+          "subGroups": []
+        }
+      ]
+    }
+  ],
+  "defaultRoles": [ ],
+  "requiredCredentials": [ "password" ],
+  "scopeMappings": [],
+  "clientScopeMappings": {
+    "microcks-app": [
+      {
+        "client": "microcks-app-js",
+        "roles": [
+          "manager",
+          "admin",
+          "user"
+        ]
+      }
+    ],
+    "realm-management": [
+      {
+        "client": "microcks-app-js",
+        "roles": [
+          "manage-users",
+          "manage-clients"
+        ]
+      }
+    ]
+  },
+  "clients": [
+    {
+      "clientId": "microcks-app-js",
+      "enabled": true,
+      "publicClient": true,
+      "redirectUris": [
+        "https://microcks-microcks.apps.cluster-tv9cn.tv9cn.sandbox140.opentlc.com/*"
+      ],
+      "webOrigins": [
+        "+"
+      ],
+      "fullScopeAllowed": false,
+      "protocolMappers": [
+        {
+          "name": "microcks-group-mapper",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-group-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "full.path": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "microcks-groups",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "applications": [
+    {
+      "name": "microcks-app",
+      "enabled": true,
+      "bearerOnly": true,
+      "defaultRoles": [
+        "user"
+      ]
+    },
+    {
+      "name": "microcks-serviceaccount",
+      "secret": "ab54d329-e435-41ae-a900-ec6b3fe15c54",
+      "enabled": true,
+      "bearerOnly": false,
+      "publicClient": false,
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "clientAuthenticatorType": "client-secret"
+    }
+  ],
+  "identityProviders": [
+  ],
+  "keycloakVersion": "10.0.1"
+}

--- a/keycloak-helm/templates/keycloak.yaml
+++ b/keycloak-helm/templates/keycloak.yaml
@@ -2,6 +2,8 @@ apiVersion: keycloak.org/v1alpha1
 kind: Keycloak
 metadata:
   name: keycloak
+  labels:
+    app: keycloak
 spec:
   instances: 1
   externalAccess:

--- a/keycloak-helm/templates/keycloak.yaml
+++ b/keycloak-helm/templates/keycloak.yaml
@@ -1,0 +1,9 @@
+apiVersion: keycloak.org/v1alpha1
+kind: Keycloak
+metadata:
+  name: keycloak
+spec:
+  instances: 1
+  externalAccess:
+    enabled: True
+  profile: RHSSO

--- a/keycloak-helm/templates/realm.yaml
+++ b/keycloak-helm/templates/realm.yaml
@@ -1,0 +1,53 @@
+apiVersion: keycloak.org/v1alpha1
+kind: KeycloakRealm
+metadata:
+  name: microcks-test
+  labels:
+    app: microcks-test
+spec:
+  instanceSelector:
+    matchLabels:
+      app: keycloak
+  realm:
+    minimumQuickLoginWaitSeconds: 60
+    accessTokenLifespanForImplicitFlow: 900
+    enabled: true
+    verifyEmail: false
+    maxFailureWaitSeconds: 900
+    rememberMe: false
+    waitIncrementSeconds: 60
+    duplicateEmailsAllowed: false
+    editUsernameAllowed: false
+    realm: microcks-test
+    registrationAllowed: false
+    permanentLockout: false
+    bruteForceProtected: false
+    failureFactor: 30
+    scopeMappings: []
+    id: microcks-test
+    accessTokenLifespan: 300
+    loginWithEmailAllowed: true
+    quickLoginCheckMilliSeconds: 1000
+    resetPasswordAllowed: false
+    maxDeltaTimeSeconds: 43200
+    clients:
+      - clientId: microcks-app-js
+        enabled: true
+        fullScopeAllowed: false
+        protocolMappers:
+          - config:
+              access.token.claim: 'true'
+              claim.name: microcks-groups
+              full.path: 'true'
+              id.token.claim: 'true'
+              userinfo.token.claim: 'true'
+            consentRequired: false
+            name: microcks-group-mapper
+            protocol: openid-connect
+            protocolMapper: oidc-group-membership-mapper
+        publicClient: true
+        redirectUris:
+          - >-
+            https://microcks-microcks.apps.{{ .Values.clusterBaseUrl }}/*
+        webOrigins:
+          - +

--- a/keycloak-helm/values.yaml
+++ b/keycloak-helm/values.yaml
@@ -1,0 +1,1 @@
+# no values for this chart yet

--- a/keycloak-helm/values.yaml
+++ b/keycloak-helm/values.yaml
@@ -1,1 +1,1 @@
-# no values for this chart yet
+clusterBaseUrl: example.cluster.com

--- a/microcks-helm/templates/route.yaml
+++ b/microcks-helm/templates/route.yaml
@@ -1,0 +1,18 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: microcks
+  labels:
+    app: microcks
+    app.kubernetes.io/instance: microcks
+    container: spring
+    group: microcks
+spec:
+  to:
+    kind: Service
+    name: microcks
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  port:
+    targetPort: spring

--- a/microcks-helm/values.yaml
+++ b/microcks-helm/values.yaml
@@ -52,7 +52,7 @@ postman:
   replicas: 1
 
 keycloak:
-  install: true
+  install: false
   realm: microcks
   # Now that we switched to newer version of Keycloak-X, default url does not contain '/auth' path
   # If you use an older external Keycloak instance, url must include the '/auth' path

--- a/microcks-helm/values.yaml
+++ b/microcks-helm/values.yaml
@@ -98,27 +98,27 @@ keycloak:
   serviceAccountCredentials: ab54d329-e435-41ae-a900-ec6b3fe15c54
 
 mongodb:
-  install: true
-  #uri: mongodb:27017
+  install: false
+  uri: mongodb:27017
   #uriParameters: "?ssl=true"
-  #database: sampledb
-  image: centos/mongodb-34-centos7:latest
-  persistent: true
-  volumeSize: 2Gi
+  database: microcks
+  #image: centos/mongodb-34-centos7:latest
+  #persistent: true
+  #volumeSize: 2Gi
   # Unless you uncomment following line and set class, persistent volume claim is created
   # with no storage class and relies on cluster default one.
   #storageClassName: my-awesome-class
   
-  username: userM
+  #username: userM
   # Unless you uncomment following line, admin password will be randomly generated.
   # Beware that in case of update, new value will be generated and overwrite existing one.
   #password: 123
 
   # Or you can uncomment secretRef block if username and password are provided through a Secret.
-  #secretRef:
-    #secret: mongodb
-    #usernameKey: database-user
-    #passwordKey: database-password
+  secretRef:
+    secret: mongodb
+    usernameKey: database-user
+    passwordKey: database-password
 
   #pvcAnnotations:
     #helm.sh/resource-policy: keep
@@ -141,7 +141,7 @@ features:
     image: quay.io/microcks/microcks-async-minion:1.7.1
 
     kafka:
-      install: true
+      install: false
       url: 192.168.99.100.nip.io
       #url: kafka-bootstrap:9092
       # Set this to your own class name if not using bare nginx

--- a/mongodb-helm/.helmignore
+++ b/mongodb-helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/mongodb-helm/Chart.yaml
+++ b/mongodb-helm/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: .
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0
+appVersion: "3.6"

--- a/mongodb-helm/templates/deployment.yaml
+++ b/mongodb-helm/templates/deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mongodb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mongodb
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: mongodb
+    spec:
+      containers:
+      - env:
+        - name: MONGODB_USER
+          valueFrom:
+            secretKeyRef:
+              key: database-user
+              name: mongodb
+        - name: MONGODB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: database-password
+              name: mongodb
+        - name: MONGODB_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: database-admin-password
+              name: mongodb
+        - name: MONGODB_DATABASE
+          valueFrom:
+            secretKeyRef:
+              key: database-name
+              name: mongodb
+        image: registry.redhat.io/rhscl/mongodb-36-rhel7:latest
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          initialDelaySeconds: 30
+          tcpSocket:
+            port: 27017
+          timeoutSeconds: 1
+        name: mongodb
+        ports:
+        - containerPort: 27017
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -i
+            - -c
+            - mongo 127.0.0.1:27017/$MONGODB_DATABASE -u $MONGODB_USER -p $MONGODB_PASSWORD
+              --eval="quit()"
+          initialDelaySeconds: 3
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 512Mi
+        securityContext:
+          capabilities: {}
+          privileged: false
+        terminationMessagePath: /dev/termination-log
+        volumeMounts:
+        - mountPath: /var/lib/mongodb/data
+          name: mongodb-data
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      volumes:
+      - name: mongodb-data
+        persistentVolumeClaim:
+          claimName: mongodb

--- a/mongodb-helm/templates/pvc.yaml
+++ b/mongodb-helm/templates/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mongodb
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/mongodb-helm/templates/secret.yaml
+++ b/mongodb-helm/templates/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mongodb
+stringData:
+  database-admin-user: admin
+  database-admin-password: 7cIKpdtrEbo3lSWe
+  database-name: microcks
+  database-password: 53K0en1Jr13yD1S5
+  database-user: user5C2

--- a/mongodb-helm/templates/service.yaml
+++ b/mongodb-helm/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb
+spec:
+  ports:
+  - name: mongo
+    nodePort: 0
+    port: 27017
+    protocol: TCP
+    targetPort: 27017
+  selector:
+    name: mongodb
+  sessionAffinity: None
+  type: ClusterIP

--- a/mongodb-helm/values.yaml
+++ b/mongodb-helm/values.yaml
@@ -1,0 +1,1 @@
+# no values for this chart yet

--- a/operators/keycloak/kustomization.yaml
+++ b/operators/keycloak/kustomization.yaml
@@ -2,7 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - cert-manager
-  - openshift-pipelines
-  - keycloak
-  - microcks
+  - subscription.yaml
+  - operatorgroup.yaml

--- a/operators/keycloak/operatorgroup.yaml
+++ b/operators/keycloak/operatorgroup.yaml
@@ -1,0 +1,9 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations:
+  name: rhsso-operator
+  namespace: keycloak
+spec:
+  targetNamespaces:
+    - keycloak

--- a/operators/keycloak/subscription.yaml
+++ b/operators/keycloak/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: rhsso-operator
+  namespace: keycloak
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: rhsso-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
- add Mongodb helm chart
- configure  Mongodb instance for Microcks
- add Keycloak helm chart
- configure central Keycloak instance for the platform
- configure Microcks to use externally-managed dependencies